### PR TITLE
Add proxy support to chrome webdriver 

### DIFF
--- a/helium/__init__.py
+++ b/helium/__init__.py
@@ -83,6 +83,32 @@ def start_chrome(url=None, headless=False):
 	"""
 	return _get_api_impl().start_chrome_impl(url, headless)
 
+def start_chrome_proxy(url, proxy, headless=False):
+	"""
+	:param url: URL to open.
+	:type url: str
+	:param proxy: The proxy address to use in the format host:port
+	:type proxy: str
+	:param headless: Whether to start Chrome in headless mode.
+	:type headless: bool
+
+	Starts an instance of Google Chrome using a proxy that is 
+	specified by a string in the format of host:port. Can optionally
+	start Chrome in headless mode. For instance::
+
+		start_chrome("whatsmyip.com", "127.0.0.1:3000")
+		start_chrome("google.com", "127.0.0.1:3000")
+		start_chrome("google.com", "127.0.0.1:3000", headless=True)
+
+	On shutdown of the Python interpreter, helium cleans up all resources used
+	for controlling the browser (such as the ChromeDriver process), but does
+	not close the browser itself. If you want to terminate the browser at the
+	end of your script, use the following command::
+
+		kill_browser()
+	"""
+	return _get_api_impl().start_chrome_proxy_impl(url, headless, proxy)
+
 def go_to(url):
 	"""
 	:param url: URL to open.

--- a/helium/_impl/__init__.py
+++ b/helium/_impl/__init__.py
@@ -102,6 +102,22 @@ class APIImpl:
 	def start_chrome_impl(self, url=None, headless=False):
 		chrome_driver = self._start_chrome_driver(headless)
 		return self._start(chrome_driver, url)
+	def start_chrome_proxy_impl(self, url=None, headless=False, proxy=None):
+		chrome_driver = self._start_chrome_driver_proxy(headless, proxy)
+		return self._start(chrome_driver, url)
+	def _start_chrome_driver_proxy(self, headless, proxy):
+		chrome_options = self._get_chrome_proxy_options(headless, proxy)
+		kwargs = self._get_chrome_driver_kwargs(chrome_options)
+		result = Chrome(**kwargs)
+		atexit.register(self._kill_service, result.service)
+		return result
+	def _get_chrome_proxy_options(self, headless, proxy):
+		result = ChromeOptions()
+		result.add_experimental_option('excludeSwitches', ['enable-logging'])
+		result.add_argument('--proxy-server=%s' % proxy)
+		if headless:
+			result.add_argument('--headless')
+		return result
 	def _start_chrome_driver(self, headless):
 		chrome_options = self._get_chrome_options(headless)
 		kwargs = self._get_chrome_driver_kwargs(chrome_options)


### PR DESCRIPTION
This allows users to start a chrome webdriver that uses a proxy. The host and port should be passed to the function start_chrome_proxy as a string in the format "host:port". Tested and working on Windows/Linux. I had wanted to add support for firefox too but configuring a proxy with the geckodriver requires a bit more and looked like it would be different depending on the OS. i didn't want people to have to pass 3 or 4 more args to the method for that so I decided i'd wait on feedback before doing that. 

let me know what you think/if you think this is the proper way to add this functionality. 