### PR TITLE
Fix firefox profile don't work with selenium 4.25.0

### DIFF
--- a/helium/_impl/__init__.py
+++ b/helium/_impl/__init__.py
@@ -86,9 +86,7 @@ class APIImpl:
 			'options': firefox_options
 		}
 		if profile:
-			# This is Deprecated in the driver so only do it (and trigger the
-			# warnings) if the user requests it
-			kwargs['firefox_profile'] = profile
+			firefox_options.profile = profile
 		service_log_path = 'nul' if is_windows() else '/dev/null'
 		service = ServiceFirefox(log_path=service_log_path)
 		result = Firefox(service=service, **kwargs)


### PR DESCRIPTION
The use of the optional parameter "profile" in `start_firefox(url, headless=False, profile=profile)` made the program crash with selenium 4.25.0.

Here is an example stacktrace encountered:

```python
Traceback (most recent call last):
  File "__main__.py", line 90, in get_html
    driver = start_firefox(url, headless=False, profile=profile)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python3.12/site-packages/helium/__init__.py", line 129, in start_firefox
    return _get_api_impl().start_firefox_impl(url, headless, options, profile)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python3.12/site-packages/helium/_impl/__init__.py", line 79, in start_firefox_impl
    firefox_driver = self._start_firefox_driver(headless, options, profile)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "python3.12/site-packages/helium/_impl/__init__.py", line 94, in _start_firefox_driver
    result = Firefox(service=service, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: WebDriver.__init__() got an unexpected keyword argument 'firefox_profile'
```

This merge request fix this error by using the `options.profile` in [selenium Firefox webdriver](https://www.selenium.dev/documentation/webdriver/browsers/firefox/) instead of kwargs.

This fix was successfully tested on my nixos computer.