### PR TITLE
Fix documentation build errors and Sphinx configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,13 @@
 version: 2
 
+python:
+   install:
+     - requirements: requirements/docs.txt
+
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 sphinx:
    configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,9 @@ release = '5.1.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.githubpages']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.githubpages', 'sphinx_rtd_theme']
+
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-sphinx-rtd-theme==0.5.0
-sphinx==3.2.1
+sphinx-rtd-theme==3.0.2
+sphinx==8.2.3


### PR DESCRIPTION
## Summary

Fix documentation build errors caused by outdated Sphinx and Jinja2 compatibility issues.  
To address this, update Sphinx and sphinx-rtd-theme versions to align with Python 3.11 support.  
Also, adjust `.readthedocs.yaml` to fix the Read the Docs deployment.

## Related Issue

Fixes #115

## Notes

- Re-applied `sphinx-rtd-theme` for styling the documentation.
- I confirmed that the documentation builds successfully locally and on Read the Docs.
- The test deployment is available [here](https://not-official-helium-docs.readthedocs.io/en/latest/api.html).
- I will remove the temporary test deployment after this PR is merged.