### PR TITLE
since 'test' is removed from modern setuptools, require <60

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 -r base.txt
 
+setuptools<60
 psutil
 pywin32; platform_system=='Windows'


### PR DESCRIPTION
Modern versions of setuptools have removed the 'test' command.  This change adds to requirements/test.txt a limit to the last version of  setuptools that supports the 'test' command.