### PR TITLE
test: add unicode press() regression tests for umlaut and CJK characters

### DIFF
--- a/tests/api/test_press.py
+++ b/tests/api/test_press.py
@@ -13,3 +13,20 @@ class PressTest(BrowserAT):
 	def test_press_shift_plus_lower_case_character(self):
 		press(SHIFT + 'a')
 		self.assertEqual('A', TextField('Autofocus text field').value)
+
+	def test_press_unicode_german_umlaut(self):
+		"""Regression test: press() should handle German umlauts correctly."""
+		press('ü')
+		self.assertEqual('ü', TextField('Autofocus text field').value)
+
+	def test_press_unicode_chinese(self):
+		"""Regression test: press() should handle CJK characters via send_keys."""
+		press('中')
+		self.assertEqual('中', TextField('Autofocus text field').value)
+
+	def test_press_unicode_combined(self):
+		"""Regression test: press() with SHIFT and unicode (e.g. ü -> Ü)."""
+		press(SHIFT + 'ü')
+		# Result depends on keyboard layout; at minimum no exception should be raised
+		field = TextField('Autofocus text field')
+		self.assertTrue(len(field.value) > 0)


### PR DESCRIPTION
## Summary
- Add 3 regression tests for press() with unicode characters (German umlauts, CJK, SHIFT+unicode)
- Test_press.py previously only covered ASCII characters (a-z, A-Z)

## Problem
tests/api/test_press.py had only ASCII test coverage. No test verified that press() correctly handles unicode input via Selenium's send_keys(). This is a regression gap — unicode support exists in the implementation but has no test.

## Solution
Add 3 targeted regression tests:
- test_press_unicode_german_umlaut: verify 'ü' works
- test_press_unicode_chinese: verify '中' works  
- test_press_unicode_combined: verify SHIFT+'ü' doesn't throw

## Tests
```bash
# Chrome (default)
python setup.py test

# Firefox
TEST_BROWSER=firefox python setup.py test
```

All tests run against test_write.html (Autofocus text field).

## Risk / Compatibility
- Risk: LOW — test-only change, no production code modified
- Affects: tests only (test_press.py)
- No public API changes
- No new dependencies